### PR TITLE
Move tests autoload config to "autoload-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,11 @@
     },
     "autoload": {
         "psr-4": {
-            "TYPO3\\PharStreamWrapper\\": "src/",
+            "TYPO3\\PharStreamWrapper\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "TYPO3\\PharStreamWrapper\\Tests\\": "tests/"
         }
     }


### PR DESCRIPTION
From [getcomposer.org/doc/04-schema.md](https://getcomposer.org/doc/04-schema.md#autoload-dev):

> Classes needed to run the test suite should not be included in the main autoload rules to avoid polluting the autoloader in production and when other people use your package as a dependency.
> 
> Therefore, it is a good idea to rely on a dedicated path for your unit tests and to add it within the autoload-dev section.