### PR TITLE
Move alias learning so only aliases of valid phar files are learnt

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -106,10 +106,11 @@ class Manager implements Assertable, Resolvable
 
     /**
      * @param string $path
+     * @param null|int $flags
+     * @return bool
      */
-    public function learnAlias(string $path)
+    public function learnAlias(string $path, int $flags = null)
     {
         return $this->resolver->learnAlias($path);
     }
-
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -103,4 +103,13 @@ class Manager implements Assertable, Resolvable
     {
         return $this->resolver->resolveBaseName($path, $flags);
     }
+
+    /**
+     * @param string $path
+     */
+    public function learnAlias(string $path)
+    {
+        return $this->resolver->learnAlias($path);
+    }
+
 }

--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -412,6 +412,7 @@ class PharStreamWrapper
     protected function assert(string $path, string $command)
     {
         if ($this->resolveAssertable()->assert($path, $command) === true) {
+            Manager::instance()->learnAlias($path);
             return;
         }
 

--- a/src/Resolvable.php
+++ b/src/Resolvable.php
@@ -20,4 +20,11 @@ interface Resolvable
      * @return null|string
      */
     public function resolveBaseName(string $path, int $flags = null);
+
+    /**
+     * @param string $path
+     * @param int|null $flags
+     * @return bool
+     */
+    public function learnAlias(string $path, int $flags = null);
 }

--- a/src/Resolver/BaseNameResolver.php
+++ b/src/Resolver/BaseNameResolver.php
@@ -47,9 +47,6 @@ class BaseNameResolver implements Resolvable
         if ($baseName !== null && $flags & static::RESOLVE_REALPATH) {
             $baseName = realpath($baseName);
         }
-        if ($baseName !== null && $hasPharPrefix && $flags & static::RESOLVE_ALIAS) {
-            $this->learnAlias($baseName);
-        }
 
         return $baseName;
     }
@@ -67,13 +64,17 @@ class BaseNameResolver implements Resolvable
 
 
     /**
-     * @param string $basePath
+     * @param string $path
      */
-    private function learnAlias(string $basePath)
+    public function learnAlias(string $path)
     {
-        $alias = (new Reader($basePath))->resolveContainer()->getAlias();
-        if ($alias !== '' && $alias !== $basePath) {
-            $this->setAlias($alias, $basePath);
+        $baseName = Helper::determineBaseFile($path);
+        if ($baseName !== null) {
+            $baseName = realpath($baseName);
+            $alias = (new Reader($baseName))->resolveContainer()->getAlias();
+            if ($alias !== '' && $alias !== $baseName) {
+                $this->setAlias($alias, $baseName);
+            }
         }
     }
 

--- a/src/Resolver/BaseNameResolver.php
+++ b/src/Resolver/BaseNameResolver.php
@@ -62,20 +62,30 @@ class BaseNameResolver implements Resolvable
         return $this->getAlias($possibleAlias ?: '');
     }
 
-
     /**
      * @param string $path
+     * @param int|null $flags
+     * @return bool
      */
-    public function learnAlias(string $path)
+    public function learnAlias(string $path, int $flags = null): bool
     {
+        $flags = $flags ?? static::RESOLVE_REALPATH;
         $baseName = Helper::determineBaseFile($path);
-        if ($baseName !== null) {
-            $baseName = realpath($baseName);
-            $alias = (new Reader($baseName))->resolveContainer()->getAlias();
-            if ($alias !== '' && $alias !== $baseName) {
-                $this->setAlias($alias, $baseName);
-            }
+        if ($baseName === null) {
+            return false;
         }
+
+        if ($flags & static::RESOLVE_REALPATH) {
+            $baseName = realpath($baseName);
+        }
+
+        $alias = (new Reader($baseName))->resolveContainer()->getAlias();
+        if ($alias === '' || $alias === $baseName) {
+            return false;
+        }
+
+        $this->setAlias($alias, $baseName);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Reviewing the latest changes with some tests I've written for Drupal showed that we're learning the alias for phar files that we're going to reject. That doesn't feel correct.