### PR TITLE
[BUGFIX] Improve End of Stub Detection

### DIFF
--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -101,21 +101,19 @@ class Reader
                 break;
             }
 
-            $stubPosition = strpos($line, '<?php');
-            $manifestPosition = strpos($line, '__HALT_COMPILER()');
+            $manifestPosition = strpos($line, '__HALT_COMPILER();');
 
-            // line contains both, start of (empty) stub and start of manifest
-            if ($stubContent === null && $stubPosition !== false
-                && $manifestContent === null && $manifestPosition !== false) {
-                $stubContent = substr($line, $stubPosition, $manifestPosition - $stubPosition - 1);
-                $manifestContent = preg_replace('#^.*__HALT_COMPILER\(\)[^>]*\?>(\r|\n)*#', '', $line);
+            // first line contains start of manifest
+            if ($stubContent === null && $manifestContent === null && $manifestPosition !== false) {
+                $stubContent = substr($line, 0, $manifestPosition - 1);
+                $manifestContent = preg_replace('#^.*__HALT_COMPILER\(\);(?>[ \n]\?>(?>\r\n|\n)?)?#', '', $line);
                 $manifestLength = $this->resolveManifestLength($manifestContent);
             // line contains start of stub
-            } elseif ($stubContent === null && $stubPosition !== false) {
-                $stubContent = substr($line, $stubPosition);
+            } elseif ($stubContent === null) {
+                $stubContent = $line;
             // line contains start of manifest
             } elseif ($manifestContent === null && $manifestPosition !== false) {
-                $manifestContent = preg_replace('#^.*__HALT_COMPILER\(\)[^>]*\?>(\r|\n)*#', '', $line);
+                $manifestContent = preg_replace('#^.*__HALT_COMPILER\(\);(?>[ \n]\?>(?>\r\n|\n)?)?#', '', $line);
                 $manifestLength = $this->resolveManifestLength($manifestContent);
             // manifest has been started (thus is cannot be stub anymore), add content
             } elseif ($manifestContent !== null) {


### PR DESCRIPTION
Previously the end of the phar stub was determined in a way which allowed
to introduce a fake manifest tricking the phar reader to think there is
no or only harmless metadata (or other wrong information).

Fix is to remove flaws in the end of stub detection which also aligns
with the [file format docs][1] and PHP's behavior. Most noteworthy:

* the stub starts always at position 0 (begin of file)
* the stub always end at "__HALT_COMPILER();"

That means there is no need to detect anything PHP at all.

For the end of stub, the used regular expression pattern did allow too
much which opened enough room to offer the phar-wrapper a fake manifest
while the original phar stream used the real one - defeating the purpose.

Therefore the regex pattern only accepts the PHP end tag if separated by
a single space and it can be followed optionally by either a single \r\n
or a single \n.

These changes also address a proof of concept attack against the phar-
wrapper and especially against the *PharMetaDataInterceptor* which was
defeated as a protector against malicious serialized data.

NOTE: attacks w/ the alias information in the manifest have not been
      checked even though they might have been affected as well.

[1]: https://www.php.net/manual/en/phar.fileformat.stub.php

Resolves: #24 