### PR TITLE
If fileinfo ext is not available use a fallback method to determine mimetype of a compressed phar file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,14 @@
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
         "php": "^7.0",
-        "ext-fileinfo": "*",
         "ext-json": "*"
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5",
+    },
+    "suggest": {
+        "ext-fileinfo": "For PHP builtin file type guessing, otherwise internal uses internal processing"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^6.5"
     },
     "suggest": {
         "ext-fileinfo": "For PHP builtin file type guessing, otherwise internal uses internal processing"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpunit/phpunit": "^6.5"
     },
     "suggest": {
-        "ext-fileinfo": "For PHP builtin file type guessing, otherwise internal uses internal processing"
+        "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
     },
     "autoload": {
         "psr-4": {

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -20,6 +20,11 @@ class Reader
     private $fileName;
 
     /**
+     * Mime-type in order to use zlib, bzip2 or no compression.
+     * In case ext-fileinfo is not present only the relevant types
+     * 'application/x-gzip' and 'application/x-bzip2' are assigned
+     * to this class property.
+     *
      * @var string
      */
     private $fileType;
@@ -161,6 +166,9 @@ class Reader
     }
 
     /**
+     * In case ext-fileinfo is not present only the relevant types
+     * 'application/x-gzip' and 'application/x-bzip2' are resolved.
+     *
      * @return string
      */
     private function determineFileTypeByHeader(): string

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -167,13 +167,13 @@ class Reader
     {
         $resource = fopen($this->fileName, 'r');
         $header = fgets($resource, 4);
+        fclose($resource);
         $mimeType = '';
-        if ($header === "\x42\x5a\x68") {
+        if (strpos($header, "\x42\x5a\x68") === 0) {
             $mimeType = 'application/x-bzip2';
         } elseif (strpos($header, "\x1f\x8b") === 0) {
             $mimeType = 'application/x-gzip';
         }
-        fclose($resource);
         return $mimeType;
     }
 

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -153,8 +153,28 @@ class Reader
      */
     private function determineFileType()
     {
-        $fileInfo = new \finfo();
-        return $fileInfo->file($this->fileName, FILEINFO_MIME_TYPE);
+        if (class_exists('\\finfo')) {
+            $fileInfo = new \finfo();
+            return $fileInfo->file($this->fileName, FILEINFO_MIME_TYPE);
+        }
+        return $this->determineFileTypeByHeader();
+    }
+
+    /**
+     * @return string
+     */
+    private function determineFileTypeByHeader(): string
+    {
+        $resource = fopen($this->fileName, 'r');
+        $header = fgets($resource, 4);
+        $mimeType = '';
+        if ($header === "\x42\x5a\x68") {
+            $mimeType = 'application/x-bzip2';
+        } elseif (strpos($header, "\x1f\x8b") === 0) {
+            $mimeType = 'application/x-gzip';
+        }
+        fclose($resource);
+        return $mimeType;
     }
 
     /**

--- a/tests/Functional/Phar/ReaderTest.php
+++ b/tests/Functional/Phar/ReaderTest.php
@@ -126,4 +126,41 @@ class ReaderTest extends TestCase
             $reader->resolveContainer()->getAlias()
         );
     }
+
+    public function mimeTypeDataProvider(): array
+    {
+        $fixturesPath = dirname(__DIR__) . '/Fixtures/';
+        return [
+            'compromised.phar.bz2' => [
+                $fixturesPath . 'compromised.phar.bz2',
+                'application/x-bzip2',
+            ],
+            'compromised.phar.gz' => [
+                $fixturesPath . 'compromised.phar.gz',
+                'application/x-gzip',
+            ],
+            'compromised.phar' => [
+                $fixturesPath . 'compromised.phar',
+                '',
+            ],
+            'compromised.phar.gz.png' => [
+                $fixturesPath . 'compromised.phar.gz.png',
+                'application/x-gzip',
+            ],
+        ];
+    }
+    /**
+     * @param string $path
+     * @param string $expectedMimeType
+     * @test
+     * @dataProvider mimeTypeDataProvider
+     */
+    public function mimeTypeCanBeDetermined(string $path, string $expectedMimeType)
+    {
+        $reader = new Reader($path);
+        $method = (new \ReflectionObject($reader))->getMethod('determineFileTypeByHeader');
+        $method->setAccessible(TRUE);
+        $this->assertSame($expectedMimeType, $method->invoke($reader));
+    }
+
 }

--- a/tests/Functional/Phar/ReaderTest.php
+++ b/tests/Functional/Phar/ReaderTest.php
@@ -127,6 +127,9 @@ class ReaderTest extends TestCase
         );
     }
 
+    /**
+     * @return array
+     */
     public function mimeTypeDataProvider(): array
     {
         $fixturesPath = dirname(__DIR__) . '/Fixtures/';
@@ -149,9 +152,11 @@ class ReaderTest extends TestCase
             ],
         ];
     }
+
     /**
      * @param string $path
      * @param string $expectedMimeType
+     *
      * @test
      * @dataProvider mimeTypeDataProvider
      */
@@ -162,5 +167,4 @@ class ReaderTest extends TestCase
         $method->setAccessible(TRUE);
         $this->assertSame($expectedMimeType, $method->invoke($reader));
     }
-
 }


### PR DESCRIPTION
The latest version forces both Drupal and Typo3 to be dependent on PHP's fileinfo extension. Previously this was only suggested for the Typo3 CMS (see https://github.com/TYPO3/TYPO3.CMS/blob/master/composer.json) and is not part of Drupal's requirements - see https://www.drupal.org/project/drupal/issues/3053552.