### PR TITLE
[TASK] Add alternative mime-type resolving

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,15 @@
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
         "php": "^5.3.3|^7.0",
-        "ext-fileinfo": "*",
         "ext-json": "*",
         "brumann/polyfill-unserialize": "^1.0"
     },
     "require-dev": {
         "ext-xdebug": "*",
         "phpunit/phpunit": "^4.8.36"
+    },
+    "suggest": {
+        "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
     },
     "autoload": {
         "psr-4": {

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -19,6 +19,11 @@ class Reader
     private $fileName;
 
     /**
+     * Mime-type in order to use zlib, bzip2 or no compression.
+     * In case ext-fileinfo is not present only the relevant types
+     * 'application/x-gzip' and 'application/x-bzip2' are assigned
+     * to this class property.
+     *
      * @var string
      */
     private $fileType;
@@ -152,8 +157,31 @@ class Reader
      */
     private function determineFileType()
     {
-        $fileInfo = new \finfo();
-        return $fileInfo->file($this->fileName, FILEINFO_MIME_TYPE);
+        if (class_exists('\\finfo')) {
+            $fileInfo = new \finfo();
+            return $fileInfo->file($this->fileName, FILEINFO_MIME_TYPE);
+        }
+        return $this->determineFileTypeByHeader();
+    }
+
+    /**
+     * In case ext-fileinfo is not present only the relevant types
+     * 'application/x-gzip' and 'application/x-bzip2' are resolved.
+     *
+     * @return string
+     */
+    private function determineFileTypeByHeader()
+    {
+        $resource = fopen($this->fileName, 'r');
+        $header = fgets($resource, 4);
+        fclose($resource);
+        $mimeType = '';
+        if (strpos($header, "\x42\x5a\x68") === 0) {
+            $mimeType = 'application/x-bzip2';
+        } elseif (strpos($header, "\x1f\x8b") === 0) {
+            $mimeType = 'application/x-gzip';
+        }
+        return $mimeType;
     }
 
     /**

--- a/tests/Functional/Phar/ReaderTest.php
+++ b/tests/Functional/Phar/ReaderTest.php
@@ -125,4 +125,46 @@ class ReaderTest extends TestCase
             $reader->resolveContainer()->getAlias()
         );
     }
+
+    /**
+     * @return array
+     */
+    public function mimeTypeDataProvider()
+    {
+        $fixturesPath = dirname(__DIR__) . '/Fixtures/';
+        return array(
+            'compromised.phar.bz2' => array(
+                $fixturesPath . 'compromised.phar.bz2',
+                'application/x-bzip2',
+            ),
+            'compromised.phar.gz' => array(
+                $fixturesPath . 'compromised.phar.gz',
+                'application/x-gzip',
+            ),
+            'compromised.phar' => array(
+                $fixturesPath . 'compromised.phar',
+                '',
+            ),
+            'compromised.phar.gz.png' => array(
+                $fixturesPath . 'compromised.phar.gz.png',
+                'application/x-gzip',
+            ),
+        );
+    }
+
+    /**
+     * @param string $path
+     * @param string $expectedMimeType
+     *
+     * @test
+     * @dataProvider mimeTypeDataProvider
+     */
+    public function mimeTypeCanBeDetermined($path, $expectedMimeType)
+    {
+        $reader = new Reader($path);
+        $object = new \ReflectionObject($reader);
+        $method = $object->getMethod('determineFileTypeByHeader');
+        $method->setAccessible(TRUE);
+        $this->assertSame($expectedMimeType, $method->invoke($reader));
+    }
 }


### PR DESCRIPTION
If fileinfo ext is not available use a fallback method
to determine mime-type of a compressed phar file