### PR TITLE
Replace deprecated curly brace array notation with common square braces.

### DIFF
--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -476,7 +476,7 @@ class PharStreamWrapper
      */
     private function invokeInternalStreamWrapper(string $functionName, ...$arguments)
     {
-        $silentExecution = $functionName{0} === '@';
+        $silentExecution = $functionName[0] === '@';
         $functionName = ltrim($functionName, '@');
         $this->restoreInternalSteamWrapper();
 


### PR DESCRIPTION
Now that php7.4.0-beta1 is out, Drupal is beginning to test against it, and eliminating this deprecation notice is an obvious first step.

https://dispatcher.drupalci.org/job/drupal8_core_regression_tests/1412/console