### PR TITLE
Allow PHPUnit 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   - php: 'nightly'
   fast_finish: true
   allow_failures:
-  - php: '7.4snapshot'
   - php: nightly
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - php: '7.3'
     env: deps=high
   - php: '7.4snapshot'
-    env: deps=high composer=--ignore-platform-reqs
+    env: composer=--ignore-platform-reqs
   - php: 'nightly'
   fast_finish: true
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^6.5|^7"
     },
     "suggest": {
         "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -145,7 +145,7 @@ class Reader
      */
     private function resolveStream(): string
     {
-        if ($this->fileType === 'application/x-gzip') {
+        if ($this->fileType === 'application/x-gzip' || $this->fileType === 'application/gzip') {
             return 'compress.zlib://';
         } elseif ($this->fileType === 'application/x-bzip2') {
             return 'compress.bzip2://';

--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -97,17 +97,13 @@ class PharExtensionInterceptorTest extends AbstractTestCase
      *
      * @test
      * @dataProvider cliToolCommandDataProvider
-     *
-     * This test currently fail on travis's 7.4snapshot build but passes using
-     * Docker's PHP7.4 RC build. Remove once there is a 7.4 stable release.
-     * @requires PHP < 7.4
      */
     public function cliToolIsExecuted(string $command)
     {
         $descriptorSpecifications = [
             ['pipe', 'r'], // STDIN -> process
             ['pipe', 'w'], // STDOUT <- process
-            ['pipe', 'a'], // STDERR
+            ['pipe', 'w'], // STDERR
         ];
         $process = proc_open('php ' . $command, $descriptorSpecifications, $pipes);
         static::assertInternalType('resource', $process);

--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -97,6 +97,10 @@ class PharExtensionInterceptorTest extends AbstractTestCase
      *
      * @test
      * @dataProvider cliToolCommandDataProvider
+     *
+     * This test currently fail on travis's 7.4snapshot build but passes using
+     * Docker's PHP7.4 RC build. Remove once there is a 7.4 stable release.
+     * @requires PHP < 7.4
      */
     public function cliToolIsExecuted(string $command)
     {


### PR DESCRIPTION
Some of the deprecation errors in PHP7.4 testing are being triggered by PHPUnit. It looks like updating to PHPUnit 7 might fix this. Part of #49 