### PR TITLE
Remove PHP7.4 workaround

### DIFF
--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -103,7 +103,7 @@ class PharExtensionInterceptorTest extends AbstractTestCase
         $descriptorSpecifications = [
             ['pipe', 'r'], // STDIN -> process
             ['pipe', 'w'], // STDOUT <- process
-            ['pipe', 'a'], // STDERR
+            ['pipe', 'w'], // STDERR
         ];
         $process = proc_open('php ' . $command, $descriptorSpecifications, $pipes);
         static::assertInternalType('resource', $process);
@@ -121,13 +121,7 @@ class PharExtensionInterceptorTest extends AbstractTestCase
         }
 
         // Ensure STDERR is empty.
-        // @todo Address 'stream_get_contents(): read of 8192 bytes failed with errno=9 Bad file descriptor'
-        // @todo Once PHP 7.4 is released
-        if (version_compare(PHP_VERSION, '7.4.0-dev') < 0) {
-            static::assertEmpty(stream_get_contents($pipes[2]));
-        } else {
-            $this->markTestIncomplete('STDERR not asserted for PHP 7.4');
-        }
+        static::assertEmpty(stream_get_contents($pipes[2]));
 
         static::assertSame([
             '__wrapped' => true,

--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -82,9 +82,10 @@ class PharExtensionInterceptorTest extends AbstractTestCase
     public function cliToolCommandDataProvider(): array
     {
         $fixtureDirectory = dirname(Helper::normalizeWindowsPath(__DIR__)) . '/Fixtures';
-        if (!is_link($fixtureDirectory . '/cli-tool')) {
-            symlink($fixtureDirectory . '/cli-tool.phar', $fixtureDirectory . '/cli-tool');
+        if (is_link($fixtureDirectory . '/cli-tool')) {
+            unlink($fixtureDirectory . '/cli-tool');
         }
+        symlink($fixtureDirectory . '/cli-tool.phar', $fixtureDirectory . '/cli-tool');
         return $this->inflateDataSet([
             // add ' --plain' in order to disable PharStreamWrapper in CLI tool
             $fixtureDirectory . '/cli-tool.phar',


### PR DESCRIPTION
I'm not sure the PHP7.4 workaround in PharExtensionInterceptorTest is actually necessary.