### PR TITLE
Do not export Appveyor config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.appveyor.yml export-ignore
 /.gitattributes export-ignore
 /.travis.yml export-ignore
 /phpunit.xml export-ignore


### PR DESCRIPTION
The release package contains an unnecessary file.