### PR TITLE
[PHP 7.4] Fix string array-access pattern to prevent deprecation errors

### DIFF
--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -476,7 +476,7 @@ class PharStreamWrapper
      */
     private function invokeInternalStreamWrapper(string $functionName, ...$arguments)
     {
-        $silentExecution = $functionName[0] === '@';
+        $silentExecution = substr($functionName, 0, 1) === '@';
         $functionName = ltrim($functionName, '@');
         $this->restoreInternalSteamWrapper();
 


### PR DESCRIPTION
PHP 7.4 deprecates the array-access pattern to access individual bytes of a string. For example, `$str[0]` and `substr($str, 0, 1)` yields same result, but the former is a shorthand and micro performance optimization to prevent a function call. 

PHP 7.4 deprecates this practice, and the following error will be thrown:

```
PHP message: PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in src/PharStreamWrapper.php on line 479
```

The fix is easy; we have to replace the array-access pattern with the typical `substr()` call, which exactly what this PR does :) This is also referenced at https://php.watch/versions/7.4/deprecated-string-array-index

Cheers. 