### PR TITLE
[TASK] Silence PHP opcache warnings

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -31,9 +31,9 @@ class Helper
     {
         if (function_exists('opcache_reset')
             && function_exists('opcache_get_status')
-            && !empty(opcache_get_status()['opcache_enabled'])
+            && !empty(@opcache_get_status()['opcache_enabled'])
         ) {
-            opcache_reset();
+            @opcache_reset();
         }
     }
 


### PR DESCRIPTION
There are some environments where `opcache.restrict_api`(https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api) is enabled for security/stability reasons. Using them produce PHP warnings

```
qente:tmp alex$ php -dopcache.restrict_api=1 -r 'require "vendor/typo3/phar-stream-wrapper/src/Helper.php";\TYPO3\PharStreamWrapper\Helper::resetOpCache();'

PHP Warning:  Zend OPcache API is restricted by "restrict_api" configuration directive in /tmp/vendor/typo3/phar-stream-wrapper/src/Helper.php on line 34

Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in /tmp/vendor/typo3/phar-stream-wrapper/src/Helper.php on line 34
```