### PR TITLE
[TASK] Silence PHP opcache warnings

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -31,9 +31,9 @@ class Helper
         if (function_exists('opcache_reset')
             && function_exists('opcache_get_status')
         ) {
-            $status = opcache_get_status();
+            $status = @opcache_get_status();
             if (!empty($status['opcache_enabled'])) {
-                opcache_reset();
+                @opcache_reset();
             }
         }
     }


### PR DESCRIPTION
There are some environments where `opcache.restrict_api`(https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.restrict-api)
is enabled for security/stability reasons. Using them produces PHP warnings like

```
PHP Warning:  Zend OPcache API is restricted by "restrict_api" configuration
directive in /tmp/vendor/typo3/phar-stream-wrapper/src/Helper.php on line 34
```