### PR TITLE
[TASK] Raise compatibility to PHP 7.1-8.4

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -36,8 +36,5 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite
-        env:
-          SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT: 1
-          SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE: 1
         run: |
           vendor/bin/simple-phpunit --colors

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -33,13 +33,7 @@ jobs:
           find . -name \*.php ! -path './vendor/*' | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Install dependencies PHP 8.2
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        if: ${{ matrix.php > '8.1' }}
-        run: composer install --prefer-dist --no-progress --no-suggest --ignore-platform-req=php+
 
       - name: Run test suite
         env:

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -37,4 +37,4 @@ jobs:
 
       - name: Run test suite
         run: |
-          vendor/bin/simple-phpunit --colors
+          vendor/bin/phpunit --colors

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Run test suite
         run: |
-          vendor/bin/simple-phpunit --colors
+          vendor/bin/phpunit --colors

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -29,19 +29,10 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         # Remove xdebug dependency as performance testing is not relevant at this point.
         run: |
           composer remove --dev --no-update ext-xdebug
           composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Install dependencies PHP 8.2
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        if: ${{ matrix.php > '8.1' }}
-        # Remove xdebug dependency as performance testing is not relevant at this point.
-        run: |
-          composer remove --dev --no-update ext-xdebug
-          composer install --prefer-dist --no-progress --no-suggest --ignore-platform-req=php+
 
       - name: Run test suite
         env:

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -35,8 +35,5 @@ jobs:
           composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite
-        env:
-          SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT: 1
-          SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE: 1
         run: |
           vendor/bin/simple-phpunit --colors

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "homepage": "https://typo3.org/",
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^7.1 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^7 || ^8 || ^9"
     },
     "suggest": {
         "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://typo3.org/",
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
-        "php": "^7.0 || ~8.0 || ~8.1 || ~8.2 || ~8.3",
+        "php": "^7.1 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://typo3.org/",
     "keywords": ["php", "phar", "stream-wrapper", "security"],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "phpspec/prophecy": "^1.10",
-        "symfony/phpunit-bridge": "^5.1"
+        "phpunit/phpunit": "^9"
     },
     "suggest": {
         "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,9 +5,6 @@
 		colors="true"
 		processIsolation="true"
 		verbose="true">
-	<php>
-	<ini name="SYMFONY_PHPUNIT_REMOVE" value="symfony/yaml"/>
-	</php>
 	<testsuites>
 		<testsuite name="functional tests">
 			<directory>tests/Functional/</directory>

--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -62,7 +62,7 @@ class Behavior implements Assertable
         return $this->assertions[$command]->assert($path, $command);
     }
 
-    private function assertCommands(array $commands)
+    private function assertCommands(array $commands): void
     {
         $unknownCommands = array_diff($commands, $this->availableCommands);
         if ($unknownCommands === []) {
@@ -77,7 +77,7 @@ class Behavior implements Assertable
         );
     }
 
-    private function assertCommand(string $command)
+    private function assertCommand(string $command): void
     {
         if (in_array($command, $this->availableCommands, true)) {
             return;
@@ -91,7 +91,7 @@ class Behavior implements Assertable
         );
     }
 
-    private function assertAssertionCompleteness()
+    private function assertAssertionCompleteness(): void
     {
         $undefinedAssertions = array_diff(
             $this->availableCommands,

--- a/src/Behavior.php
+++ b/src/Behavior.php
@@ -14,14 +14,14 @@ namespace TYPO3\PharStreamWrapper;
 
 class Behavior implements Assertable
 {
-    const COMMAND_DIR_OPENDIR = 'dir_opendir';
-    const COMMAND_MKDIR = 'mkdir';
-    const COMMAND_RENAME = 'rename';
-    const COMMAND_RMDIR = 'rmdir';
-    const COMMAND_STEAM_METADATA = 'stream_metadata';
-    const COMMAND_STREAM_OPEN = 'stream_open';
-    const COMMAND_UNLINK = 'unlink';
-    const COMMAND_URL_STAT = 'url_stat';
+    public const COMMAND_DIR_OPENDIR = 'dir_opendir';
+    public const COMMAND_MKDIR = 'mkdir';
+    public const COMMAND_RENAME = 'rename';
+    public const COMMAND_RMDIR = 'rmdir';
+    public const COMMAND_STEAM_METADATA = 'stream_metadata';
+    public const COMMAND_STREAM_OPEN = 'stream_open';
+    public const COMMAND_UNLINK = 'unlink';
+    public const COMMAND_URL_STAT = 'url_stat';
 
     /**
      * @var string[]

--- a/src/Collectable.php
+++ b/src/Collectable.php
@@ -21,11 +21,11 @@ interface Collectable
     /**
      * @param int|null $flags
      */
-    public function collect(PharInvocation $invocation, int $flags = null): bool;
+    public function collect(PharInvocation $invocation, ?int $flags = null): bool;
 
     /**
      * @param bool $reverse
      * @return null|PharInvocation
      */
-    public function findByCallback(callable $callback, $reverse = false);
+    public function findByCallback(callable $callback, bool $reverse = false);
 }

--- a/src/Collectable.php
+++ b/src/Collectable.php
@@ -18,14 +18,7 @@ interface Collectable
 {
     public function has(PharInvocation $invocation): bool;
 
-    /**
-     * @param int|null $flags
-     */
     public function collect(PharInvocation $invocation, ?int $flags = null): bool;
 
-    /**
-     * @param bool $reverse
-     * @return null|PharInvocation
-     */
-    public function findByCallback(callable $callback, bool $reverse = false);
+    public function findByCallback(callable $callback, bool $reverse = false): ?PharInvocation;
 }

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -27,7 +27,7 @@ class Helper
      *
      * @see https://bugs.php.net/bug.php?id=66569
      */
-    public static function resetOpCache()
+    public static function resetOpCache(): void
     {
         if (function_exists('opcache_reset')
             && function_exists('opcache_get_status')
@@ -41,10 +41,8 @@ class Helper
      * Determines base file that can be accessed using the regular file system.
      * For e.g. "phar:///home/user/bundle.phar/content.txt" that would result
      * into "/home/user/bundle.phar".
-     *
-     * @return string|null
      */
-    public static function determineBaseFile(string $path)
+    public static function determineBaseFile(string $path): ?string
     {
         $parts = explode('/', static::normalizePath($path));
 

--- a/src/Interceptor/ConjunctionInterceptor.php
+++ b/src/Interceptor/ConjunctionInterceptor.php
@@ -53,7 +53,7 @@ class ConjunctionInterceptor implements Assertable
     /**
      * @param Assertable[] $assertions
      */
-    private function assertAssertions(array $assertions)
+    private function assertAssertions(array $assertions): void
     {
         foreach ($assertions as $assertion) {
             if (!$assertion instanceof Assertable) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -88,10 +88,7 @@ class Manager
         return $this->behavior->assert($path, $command);
     }
 
-    /**
-     * @return PharInvocation|null
-     */
-    public function resolve(string $path, ?int $flags = null)
+    public function resolve(string $path, ?int $flags = null): ?PharInvocation
     {
         return $this->resolver->resolve($path, $flags);
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -40,8 +40,8 @@ class Manager
 
     public static function initialize(
         Behavior $behaviour,
-        Resolvable $resolver = null,
-        Collectable $collection = null
+        ?Resolvable $resolver = null,
+        ?Collectable $collection = null
     ): self {
         if (self::$instance === null) {
             self::$instance = new self($behaviour, $resolver, $collection);
@@ -75,8 +75,8 @@ class Manager
 
     private function __construct(
         Behavior $behaviour,
-        Resolvable $resolver = null,
-        Collectable $collection = null
+        ?Resolvable $resolver = null,
+        ?Collectable $collection = null
     ) {
         $this->collection = $collection ?? new PharInvocationCollection();
         $this->resolver = $resolver ?? new PharInvocationResolver();
@@ -91,7 +91,7 @@ class Manager
     /**
      * @return PharInvocation|null
      */
-    public function resolve(string $path, int $flags = null)
+    public function resolve(string $path, ?int $flags = null)
     {
         return $this->resolver->resolve($path, $flags);
     }

--- a/src/Phar/Reader.php
+++ b/src/Phar/Reader.php
@@ -182,10 +182,7 @@ class Reader
         return '';
     }
 
-    /**
-     * @return int|null
-     */
-    private function resolveManifestLength(string $content)
+    private function resolveManifestLength(string $content): ?int
     {
         if (strlen($content) < 4) {
             return null;

--- a/src/Phar/Stub.php
+++ b/src/Phar/Stub.php
@@ -44,10 +44,7 @@ class Stub
      */
     private $mappedAlias = '';
 
-    /**
-     * @return null|string
-     */
-    public function getContent()
+    public function getContent(): ?string
     {
         return $this->content;
     }

--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -20,7 +20,7 @@ class PharStreamWrapper
      * Internal stream constants that are not exposed to PHP, but used...
      * @see https://github.com/php/php-src/blob/e17fc0d73c611ad0207cac8a4a01ded38251a7dc/main/php_streams.h
      */
-    const STREAM_OPEN_FOR_INCLUDE = 128;
+    public const STREAM_OPEN_FOR_INCLUDE = 128;
 
     /**
      * @var resource

--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -204,7 +204,7 @@ class PharStreamWrapper
         string $path,
         string $mode,
         int $options,
-        string &$opened_path = null
+        ?string &$opened_path = null
     ): bool {
         $this->assert($path, Behavior::COMMAND_STREAM_OPEN);
         $arguments = [$path, $mode, (bool) ($options & STREAM_USE_PATH)];

--- a/src/PharStreamWrapper.php
+++ b/src/PharStreamWrapper.php
@@ -119,7 +119,7 @@ class PharStreamWrapper
         );
     }
 
-    public function stream_cast(int $cast_as)
+    public function stream_cast(int $cast_as): void
     {
         throw new Exception(
             'Method stream_select() cannot be used',
@@ -127,7 +127,7 @@ class PharStreamWrapper
         );
     }
 
-    public function stream_close()
+    public function stream_close(): void
     {
         $this->invokeInternalStreamWrapper(
             'fclose',
@@ -330,7 +330,7 @@ class PharStreamWrapper
         return $this->invokeInternalStreamWrapper($functionName, $path);
     }
 
-    protected function assert(string $path, string $command)
+    protected function assert(string $path, string $command): void
     {
         if (Manager::instance()->assert($path, $command) === true) {
             $this->collectInvocation($path);
@@ -347,7 +347,7 @@ class PharStreamWrapper
         );
     }
 
-    protected function collectInvocation(string $path)
+    protected function collectInvocation(string $path): void
     {
         if (isset($this->invocation)) {
             return;
@@ -403,7 +403,7 @@ class PharStreamWrapper
         return $result;
     }
 
-    private function restoreInternalSteamWrapper()
+    private function restoreInternalSteamWrapper(): void
     {
         if (PHP_VERSION_ID < 70324
             || PHP_VERSION_ID >= 70400 && PHP_VERSION_ID < 70412) {
@@ -416,7 +416,7 @@ class PharStreamWrapper
         }
     }
 
-    private function registerStreamWrapper()
+    private function registerStreamWrapper(): void
     {
         stream_wrapper_unregister('phar');
         stream_wrapper_register('phar', static::class);

--- a/src/Resolvable.php
+++ b/src/Resolvable.php
@@ -21,5 +21,5 @@ interface Resolvable
      * @param null|int $flags
      * @return null|PharInvocation
      */
-    public function resolve(string $path, int $flags = null);
+    public function resolve(string $path, ?int $flags = null);
 }

--- a/src/Resolvable.php
+++ b/src/Resolvable.php
@@ -16,10 +16,5 @@ use TYPO3\PharStreamWrapper\Resolver\PharInvocation;
 
 interface Resolvable
 {
-    /**
-     * @param string $path
-     * @param null|int $flags
-     * @return null|PharInvocation
-     */
-    public function resolve(string $path, ?int $flags = null);
+    public function resolve(string $path, ?int $flags = null): ?PharInvocation;
 }

--- a/src/Resolver/PharInvocation.php
+++ b/src/Resolver/PharInvocation.php
@@ -88,13 +88,12 @@ class PharInvocation
         return $this->confirmed;
     }
 
-    public function confirm()
+    public function confirm(): void
     {
         $this->confirmed = true;
     }
 
     /**
-     * @param string $name
      * @return mixed|null
      */
     public function getVariable(string $name)
@@ -103,10 +102,9 @@ class PharInvocation
     }
 
     /**
-     * @param string $name
      * @param mixed $value
      */
-    public function setVariable(string $name, $value)
+    public function setVariable(string $name, $value): void
     {
         $this->variables[$name] = $value;
     }

--- a/src/Resolver/PharInvocationCollection.php
+++ b/src/Resolver/PharInvocationCollection.php
@@ -39,7 +39,7 @@ class PharInvocationCollection implements Collectable
      * @param null|int $flags
      * @return bool
      */
-    public function collect(PharInvocation $invocation, int $flags = null): bool
+    public function collect(PharInvocation $invocation, ?int $flags = null): bool
     {
         if ($flags === null) {
             $flags = static::UNIQUE_INVOCATION | static::DUPLICATE_ALIAS_WARNING;
@@ -64,7 +64,7 @@ class PharInvocationCollection implements Collectable
      * @param bool $reverse
      * @return null|PharInvocation
      */
-    public function findByCallback(callable $callback, $reverse = false)
+    public function findByCallback(callable $callback, bool $reverse = false)
     {
         foreach ($this->getInvocations($reverse) as $invocation) {
             if (call_user_func($callback, $invocation) === true) {

--- a/src/Resolver/PharInvocationCollection.php
+++ b/src/Resolver/PharInvocationCollection.php
@@ -16,9 +16,9 @@ use TYPO3\PharStreamWrapper\Collectable;
 
 class PharInvocationCollection implements Collectable
 {
-    const UNIQUE_INVOCATION = 1;
-    const UNIQUE_BASE_NAME = 2;
-    const DUPLICATE_ALIAS_WARNING = 32;
+    public const UNIQUE_INVOCATION = 1;
+    public const UNIQUE_BASE_NAME = 2;
+    public const DUPLICATE_ALIAS_WARNING = 32;
 
     /**
      * @var PharInvocation[]

--- a/src/Resolver/PharInvocationCollection.php
+++ b/src/Resolver/PharInvocationCollection.php
@@ -59,12 +59,7 @@ class PharInvocationCollection implements Collectable
         return true;
     }
 
-    /**
-     * @param callable $callback
-     * @param bool $reverse
-     * @return null|PharInvocation
-     */
-    public function findByCallback(callable $callback, bool $reverse = false)
+    public function findByCallback(callable $callback, bool $reverse = false): ?PharInvocation
     {
         foreach ($this->getInvocations($reverse) as $invocation) {
             if (call_user_func($callback, $invocation) === true) {
@@ -117,10 +112,9 @@ class PharInvocationCollection implements Collectable
     /**
      * Triggers warning for invocations with same alias and same confirmation state.
      *
-     * @param PharInvocation $invocation
      * @see \TYPO3\PharStreamWrapper\PharStreamWrapper::collectInvocation()
      */
-    private function triggerDuplicateAliasWarning(PharInvocation $invocation)
+    private function triggerDuplicateAliasWarning(PharInvocation $invocation): void
     {
         $sameAliasInvocation = $this->findByCallback(
             function (PharInvocation $candidate) use ($invocation) {

--- a/src/Resolver/PharInvocationResolver.php
+++ b/src/Resolver/PharInvocationResolver.php
@@ -57,7 +57,7 @@ class PharInvocationResolver implements Resolvable
      * @param int|null $flags
      * @return null|PharInvocation
      */
-    public function resolve(string $path, int $flags = null)
+    public function resolve(string $path, ?int $flags = null)
     {
         $hasPharPrefix = Helper::hasPharPrefix($path);
         $flags = $flags ?? static::RESOLVE_REALPATH | static::RESOLVE_ALIAS;

--- a/src/Resolver/PharInvocationResolver.php
+++ b/src/Resolver/PharInvocationResolver.php
@@ -52,12 +52,8 @@ class PharInvocationResolver implements Resolvable
      * one $baseName is referring to multiple aliases.
      * @see https://secure.php.net/manual/en/phar.setalias.php
      * @see https://secure.php.net/manual/en/phar.mapphar.php
-     *
-     * @param string $path
-     * @param int|null $flags
-     * @return null|PharInvocation
      */
-    public function resolve(string $path, ?int $flags = null)
+    public function resolve(string $path, ?int $flags = null): ?PharInvocation
     {
         $hasPharPrefix = Helper::hasPharPrefix($path);
         $flags = $flags ?? static::RESOLVE_REALPATH | static::RESOLVE_ALIAS;
@@ -107,12 +103,7 @@ class PharInvocationResolver implements Resolvable
         return $invocation;
     }
 
-    /**
-     * @param string $path
-     * @param int $flags
-     * @return null|string
-     */
-    private function resolveBaseName(string $path, int $flags)
+    private function resolveBaseName(string $path, int $flags): ?string
     {
         $baseName = $this->findInBaseNames($path);
         if ($baseName !== null) {
@@ -162,21 +153,13 @@ class PharInvocationResolver implements Resolvable
         return null;
     }
 
-    /**
-     * @param string $path
-     * @return null|string
-     */
-    private function resolvePossibleAlias(string $path)
+    private function resolvePossibleAlias(string $path): ?string
     {
         $normalizedPath = Helper::normalizePath($path);
         return strstr($normalizedPath, '/', true) ?: null;
     }
 
-    /**
-     * @param string $baseName
-     * @return null|PharInvocation
-     */
-    private function findByBaseName(string $baseName)
+    private function findByBaseName(string $baseName): ?PharInvocation
     {
         return Manager::instance()->getCollection()->findByCallback(
             function (PharInvocation $candidate) use ($baseName) {
@@ -186,11 +169,7 @@ class PharInvocationResolver implements Resolvable
         );
     }
 
-    /**
-     * @param string $path
-     * @return null|string
-     */
-    private function findInBaseNames(string $path)
+    private function findInBaseNames(string $path): ?string
     {
         // return directly if the resolved base name was submitted
         if (in_array($path, $this->baseNames, true)) {
@@ -210,10 +189,7 @@ class PharInvocationResolver implements Resolvable
         return null;
     }
 
-    /**
-     * @param string $baseName
-     */
-    private function addBaseName(string $baseName)
+    private function addBaseName(string $baseName): void
     {
         if (isset($this->baseNames[$baseName])) {
             return;
@@ -226,11 +202,9 @@ class PharInvocationResolver implements Resolvable
     /**
      * Finds confirmed(!) invocations by alias.
      *
-     * @param string $path
-     * @return null|PharInvocation
      * @see \TYPO3\PharStreamWrapper\PharStreamWrapper::collectInvocation()
      */
-    private function findByAlias(string $path)
+    private function findByAlias(string $path): ?PharInvocation
     {
         $possibleAlias = $this->resolvePossibleAlias($path);
         if ($possibleAlias === null) {

--- a/src/Resolver/PharInvocationResolver.php
+++ b/src/Resolver/PharInvocationResolver.php
@@ -20,9 +20,9 @@ use TYPO3\PharStreamWrapper\Resolvable;
 
 class PharInvocationResolver implements Resolvable
 {
-    const RESOLVE_REALPATH = 1;
-    const RESOLVE_ALIAS = 2;
-    const ASSERT_INTERNAL_INVOCATION = 32;
+    public const RESOLVE_REALPATH = 1;
+    public const RESOLVE_ALIAS = 2;
+    public const ASSERT_INTERNAL_INVOCATION = 32;
 
     /**
      * @var string[]

--- a/tests/Functional/HelperTest.php
+++ b/tests/Functional/HelperTest.php
@@ -67,7 +67,7 @@ class HelperTest extends TestCase
      * @test
      * @dataProvider baseFileIsResolvedDataProvider
      */
-    public function baseFileIsResolved(string $path, ?string $expectation = null)
+    public function baseFileIsResolved(string $path, ?string $expectation = null): void
     {
         static::assertSame(
             $expectation,

--- a/tests/Functional/HelperTest.php
+++ b/tests/Functional/HelperTest.php
@@ -67,7 +67,7 @@ class HelperTest extends TestCase
      * @test
      * @dataProvider baseFileIsResolvedDataProvider
      */
-    public function baseFileIsResolved(string $path, string $expectation = null)
+    public function baseFileIsResolved(string $path, ?string $expectation = null)
     {
         static::assertSame(
             $expectation,

--- a/tests/Functional/Interceptor/AbstractTestCase.php
+++ b/tests/Functional/Interceptor/AbstractTestCase.php
@@ -37,7 +37,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * @var int
      */
-    const EXPECTED_EXCEPTION_CODE = 0;
+    protected const EXPECTED_EXCEPTION_CODE = 0;
 
     public function allowedPathsDataProvider(): array
     {
@@ -99,7 +99,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * @test
      */
-    public function directoryOpenDeniesInvocationAfterCatchingError()
+    public function directoryOpenDeniesInvocationAfterCatchingError(): void
     {
         if ($this->allowedPaths === [] || $this->deniedPaths === []) {
             $this->markTestSkipped('No ALLOWED_PATHS and DENIED_PATHS defined');
@@ -120,7 +120,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * @test
      */
-    public function directoryOpenDeniesInvocationAfterCatchingException()
+    public function directoryOpenDeniesInvocationAfterCatchingException(): void
     {
         if ($this->allowedPaths === [] || $this->deniedPaths === []) {
             $this->markTestSkipped('No ALLOWED_PATHS and DENIED_PATHS defined');
@@ -143,7 +143,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider directoryActionAllowsInvocationDataProvider
      */
-    public function directoryReadAllowsInvocation(string $path, array $expectation)
+    public function directoryReadAllowsInvocation(string $path, array $expectation): void
     {
         $items = [];
         $handle = opendir('phar://' . $path);
@@ -193,7 +193,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider directoryActionDeniesInvocationDataProvider
      */
-    public function directoryActionDeniesInvocation(string $path)
+    public function directoryActionDeniesInvocation(string $path): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(static::EXPECTED_EXCEPTION_CODE);
@@ -257,7 +257,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider urlStatAllowsInvocationDataProvider
      */
-    public function urlStatAllowsInvocation(string $functionName, string $path, $expectation)
+    public function urlStatAllowsInvocation(string $functionName, string $path, $expectation): void
     {
         self::assertSame(
             $expectation,
@@ -320,7 +320,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider urlStatDeniesInvocationDataProvider
      */
-    public function urlStatDeniesInvocation(string $functionName, string $path)
+    public function urlStatDeniesInvocation(string $functionName, string $path): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(static::EXPECTED_EXCEPTION_CODE);
@@ -331,7 +331,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForFileOpen(string $allowedPath)
+    public function streamOpenAllowsInvocationForFileOpen(string $allowedPath): void
     {
         $handle = fopen('phar://' . $allowedPath . '/Resources/content.txt', 'r');
         self::assertIsResource($handle);
@@ -341,7 +341,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForFileRead(string $allowedPath)
+    public function streamOpenAllowsInvocationForFileRead(string $allowedPath): void
     {
         $handle = fopen('phar://' . $allowedPath . '/Resources/content.txt', 'r');
         $content = fread($handle, 1024);
@@ -352,7 +352,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForFileEnd(string $allowedPath)
+    public function streamOpenAllowsInvocationForFileEnd(string $allowedPath): void
     {
         $handle = fopen('phar://' . $allowedPath . '/Resources/content.txt', 'r');
         fread($handle, 1024);
@@ -363,7 +363,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForFileClose(string $allowedPath)
+    public function streamOpenAllowsInvocationForFileClose(string $allowedPath): void
     {
         $handle = fopen('phar://' . $allowedPath . '/Resources/content.txt', 'r');
         fclose($handle);
@@ -374,7 +374,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForFileGetContents(string $allowedPath)
+    public function streamOpenAllowsInvocationForFileGetContents(string $allowedPath): void
     {
         $content = file_get_contents('phar://' . $allowedPath . '/Resources/content.txt');
         self::assertSame('TYPO3 demo text file.', $content);
@@ -384,7 +384,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForInclude(string $allowedPath)
+    public function streamOpenAllowsInvocationForInclude(string $allowedPath): void
     {
         include('phar://' . $allowedPath . '/Classes/Domain/Model/DemoModel.php');
         self::assertTrue(
@@ -399,7 +399,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider allowedAliasedPathsDataProvider
      */
-    public function streamOpenAllowsInvocationForIncludeOnAliasedPhar(string $allowedPath)
+    public function streamOpenAllowsInvocationForIncludeOnAliasedPhar(string $allowedPath): void
     {
         $result = include($allowedPath);
         static::assertNotFalse($result);
@@ -409,7 +409,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider deniedPathsDataProvider
      */
-    public function streamOpenDeniesInvocationForFileOpen(string $deniedPath)
+    public function streamOpenDeniesInvocationForFileOpen(string $deniedPath): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(static::EXPECTED_EXCEPTION_CODE);
@@ -420,7 +420,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider deniedPathsDataProvider
      */
-    public function streamOpenDeniesInvocationForFileGetContents(string $deniedPath)
+    public function streamOpenDeniesInvocationForFileGetContents(string $deniedPath): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(static::EXPECTED_EXCEPTION_CODE);
@@ -431,7 +431,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider deniedPathsDataProvider
      */
-    public function streamOpenDeniesInvocationForInclude(string $deniedPath)
+    public function streamOpenDeniesInvocationForInclude(string $deniedPath): void
     {
         $this->expectException(Exception::class);
         $this->expectExceptionCode(static::EXPECTED_EXCEPTION_CODE);
@@ -445,7 +445,7 @@ abstract class AbstractTestCase extends TestCase
      * @dataProvider isFileSystemInvocationAcceptableDataProvider
      * @throws \MaxMind\Db\Reader\InvalidDatabaseException
      */
-    public function isFileSystemInvocationAcceptable(string $path, array $expectation)
+    public function isFileSystemInvocationAcceptable(string $path, array $expectation): void
     {
         if (!extension_loaded('xdebug')) {
             $this->markTestSkipped('xdebug not available');

--- a/tests/Functional/Interceptor/AbstractTestCase.php
+++ b/tests/Functional/Interceptor/AbstractTestCase.php
@@ -87,7 +87,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider directoryActionAllowsInvocationDataProvider
      */
-    public function directoryOpenAllowsInvocation(string $path)
+    public function directoryOpenAllowsInvocation(string $path): void
     {
         $handle = opendir('phar://' . $path);
         self::assertIsResource($handle);
@@ -155,7 +155,7 @@ abstract class AbstractTestCase extends TestCase
      * @test
      * @dataProvider directoryActionAllowsInvocationDataProvider
      */
-    public function directoryCloseAllowsInvocation(string $path)
+    public function directoryCloseAllowsInvocation(string $path): void
     {
         $handle = opendir('phar://' . $path);
         closedir($handle);

--- a/tests/Functional/Interceptor/AbstractTestCase.php
+++ b/tests/Functional/Interceptor/AbstractTestCase.php
@@ -34,9 +34,6 @@ abstract class AbstractTestCase extends TestCase
      */
     protected $deniedPaths = [];
 
-    /**
-     * @var int
-     */
     protected const EXPECTED_EXCEPTION_CODE = 0;
 
     public function allowedPathsDataProvider(): array

--- a/tests/Functional/Interceptor/ConjunctionInterceptorTest.php
+++ b/tests/Functional/Interceptor/ConjunctionInterceptorTest.php
@@ -59,9 +59,9 @@ class ConjunctionInterceptorTest extends AbstractTestCase
     /**
      * @var int
      */
-    const EXPECTED_EXCEPTION_CODE = 1539625084;
+    protected const EXPECTED_EXCEPTION_CODE = 1539625084;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!in_array('phar', stream_get_wrappers())) {
             $this->markTestSkipped('Phar stream wrapper is not registered');
@@ -79,7 +79,7 @@ class ConjunctionInterceptorTest extends AbstractTestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         stream_wrapper_restore('phar');
         Manager::destroy();

--- a/tests/Functional/Interceptor/ConjunctionInterceptorTest.php
+++ b/tests/Functional/Interceptor/ConjunctionInterceptorTest.php
@@ -56,9 +56,6 @@ class ConjunctionInterceptorTest extends AbstractTestCase
         __DIR__ . '/../Fixtures/compromised.phar.png/../bundle.phar',
     ];
 
-    /**
-     * @var int
-     */
     protected const EXPECTED_EXCEPTION_CODE = 1539625084;
 
     protected function setUp(): void

--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -48,9 +48,6 @@ class PharExtensionInterceptorTest extends AbstractTestCase
         __DIR__ . '/../Fixtures/compromised.phar.png/../bundle.phar',
     ];
 
-    /**
-     * @var int
-     */
     protected const EXPECTED_EXCEPTION_CODE = 1535198703;
 
     protected function setUp(): void

--- a/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharExtensionInterceptorTest.php
@@ -51,9 +51,9 @@ class PharExtensionInterceptorTest extends AbstractTestCase
     /**
      * @var int
      */
-    const EXPECTED_EXCEPTION_CODE = 1535198703;
+    protected const EXPECTED_EXCEPTION_CODE = 1535198703;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!in_array('phar', stream_get_wrappers())) {
             $this->markTestSkipped('Phar stream wrapper is not registered');
@@ -68,7 +68,7 @@ class PharExtensionInterceptorTest extends AbstractTestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         stream_wrapper_restore('phar');
         Manager::destroy();
@@ -92,7 +92,7 @@ class PharExtensionInterceptorTest extends AbstractTestCase
      * @test
      * @dataProvider cliToolCommandDataProvider
      */
-    public function cliToolIsExecuted(string $command)
+    public function cliToolIsExecuted(string $command): void
     {
         $descriptorSpecifications = [
             ['pipe', 'r'], // STDIN -> process

--- a/tests/Functional/Interceptor/PharMetaDataInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharMetaDataInterceptorTest.php
@@ -54,9 +54,6 @@ class PharMetaDataInterceptorTest extends AbstractTestCase
         __DIR__ . '/../Fixtures/compromised.phar/../bundle.phar',
     ];
 
-    /**
-     * @var int
-     */
     protected const EXPECTED_EXCEPTION_CODE = 1539632368;
 
     protected function setUp(): void

--- a/tests/Functional/Interceptor/PharMetaDataInterceptorTest.php
+++ b/tests/Functional/Interceptor/PharMetaDataInterceptorTest.php
@@ -57,9 +57,9 @@ class PharMetaDataInterceptorTest extends AbstractTestCase
     /**
      * @var int
      */
-    const EXPECTED_EXCEPTION_CODE = 1539632368;
+    protected const EXPECTED_EXCEPTION_CODE = 1539632368;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!in_array('phar', stream_get_wrappers())) {
             $this->markTestSkipped('Phar stream wrapper is not registered');
@@ -74,7 +74,7 @@ class PharMetaDataInterceptorTest extends AbstractTestCase
         );
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         stream_wrapper_restore('phar');
         Manager::destroy();

--- a/tests/Functional/Phar/ReaderTest.php
+++ b/tests/Functional/Phar/ReaderTest.php
@@ -17,10 +17,10 @@ use TYPO3\PharStreamWrapper\Phar\Reader;
 
 class ReaderTest extends TestCase
 {
-    const CONTAINER_ALIAS = 'container.alias';
-    const STUB_MAPPED_ALIAS = 'stub.mappedAlias';
-    const STUB_CONTENT_FLAG = 'stub.containerFlag';
-    const MANIFEST_ALIAS = 'manifest.alias';
+    private const CONTAINER_ALIAS = 'container.alias';
+    private const STUB_MAPPED_ALIAS = 'stub.mappedAlias';
+    private const STUB_CONTENT_FLAG = 'stub.containerFlag';
+    private const MANIFEST_ALIAS = 'manifest.alias';
 
     public function pharAliasDataProvider(): array
     {

--- a/tests/Functional/Phar/ReaderTest.php
+++ b/tests/Functional/Phar/ReaderTest.php
@@ -71,7 +71,7 @@ class ReaderTest extends TestCase
      * @test
      * @dataProvider pharAliasDataProvider
      */
-    public function pharStubContentFlagCanBeResolved(string $path, array $expectations)
+    public function pharStubContentFlagCanBeResolved(string $path, array $expectations): void
     {
         $reader = new Reader($path);
         $this->assertStringContainsString(
@@ -84,7 +84,7 @@ class ReaderTest extends TestCase
      * @test
      * @dataProvider pharAliasDataProvider
      */
-    public function pharStubMappedAliasCanBeResolved(string $path, array $expectations)
+    public function pharStubMappedAliasCanBeResolved(string $path, array $expectations): void
     {
         $reader = new Reader($path);
         $this->assertSame(
@@ -97,7 +97,7 @@ class ReaderTest extends TestCase
      * @test
      * @dataProvider pharAliasDataProvider
      */
-    public function pharManifestAliasCanBeResolved(string $path, array $expectations)
+    public function pharManifestAliasCanBeResolved(string $path, array $expectations): void
     {
         $reader = new Reader($path);
         $this->assertSame(
@@ -110,7 +110,7 @@ class ReaderTest extends TestCase
      * @test
      * @dataProvider pharAliasDataProvider
      */
-    public function pharContainerAliasCanBeResolved(string $path, array $expectations)
+    public function pharContainerAliasCanBeResolved(string $path, array $expectations): void
     {
         $reader = new Reader($path);
         $this->assertSame(
@@ -146,7 +146,7 @@ class ReaderTest extends TestCase
      * @test
      * @dataProvider mimeTypeDataProvider
      */
-    public function mimeTypeCanBeDetermined(string $path, string $expectedMimeType)
+    public function mimeTypeCanBeDetermined(string $path, string $expectedMimeType): void
     {
         $reader = new Reader($path);
         $method = (new \ReflectionObject($reader))->getMethod('determineFileTypeByHeader');

--- a/tests/Functional/Resolver/PharInvocationResolverTest.php
+++ b/tests/Functional/Resolver/PharInvocationResolverTest.php
@@ -24,13 +24,13 @@ class PharInvocationResolverTest extends TestCase
      */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         Manager::initialize(new Behavior());
         $this->subject = new PharInvocationResolver();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($this->subject);
         Manager::destroy();
@@ -81,7 +81,7 @@ class PharInvocationResolverTest extends TestCase
      * @test
      * @dataProvider invocationIsResolvedDataProvider
      */
-    public function invocationIsResolved(string $path, ?int $flags, array $expectations)
+    public function invocationIsResolved(string $path, ?int $flags, array $expectations): void
     {
         $invocation = $this->subject->resolve($path, $flags);
         static::assertSame($invocation->getBaseName(), $expectations['baseName']);
@@ -105,7 +105,7 @@ class PharInvocationResolverTest extends TestCase
      * @test
      * @dataProvider invocationIsNotResolvedDataProvider
      */
-    public function invocationIsNotResolved(string $path, ?int $flags = null)
+    public function invocationIsNotResolved(string $path, ?int $flags = null): void
     {
         $invocation = $this->subject->resolve($path, $flags);
         static::assertNull($invocation);

--- a/tests/Functional/Resolver/PharInvocationResolverTest.php
+++ b/tests/Functional/Resolver/PharInvocationResolverTest.php
@@ -81,7 +81,7 @@ class PharInvocationResolverTest extends TestCase
      * @test
      * @dataProvider invocationIsResolvedDataProvider
      */
-    public function invocationIsResolved(string $path, $flags, array $expectations)
+    public function invocationIsResolved(string $path, ?int $flags, array $expectations)
     {
         $invocation = $this->subject->resolve($path, $flags);
         static::assertSame($invocation->getBaseName(), $expectations['baseName']);
@@ -105,7 +105,7 @@ class PharInvocationResolverTest extends TestCase
      * @test
      * @dataProvider invocationIsNotResolvedDataProvider
      */
-    public function invocationIsNotResolved(string $path, int $flags = null)
+    public function invocationIsNotResolved(string $path, ?int $flags = null)
     {
         $invocation = $this->subject->resolve($path, $flags);
         static::assertNull($invocation);

--- a/tests/Unit/HelperTest.php
+++ b/tests/Unit/HelperTest.php
@@ -37,7 +37,7 @@ class HelperTest extends TestCase
      * @test
      * @dataProvider pharPrefixIsRemovedDataProvider
      */
-    public function pharPrefixIsRemoved(string $path, string $expectation)
+    public function pharPrefixIsRemoved(string $path, string $expectation): void
     {
         static::assertSame(
             $expectation,
@@ -68,7 +68,7 @@ class HelperTest extends TestCase
      * @test
      * @dataProvider pathIsNormalizedDataProvider
      */
-    public function pathIsNormalized(string $path, string $expectation)
+    public function pathIsNormalized(string $path, string $expectation): void
     {
         static::assertSame(
             $expectation,

--- a/tests/Unit/ManagerTest.php
+++ b/tests/Unit/ManagerTest.php
@@ -22,33 +22,33 @@ class ManagerTest extends TestCase
     /**
      * @var ObjectProphecy|Behavior
      */
-    private $behaviorProphecy;
+    private $behaviorMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->behaviorProphecy = $this->prophesize(Behavior::class);
+        $this->behaviorMock = $this->createMock(Behavior::class);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
-        unset($this->behaviorProphecy);
+        unset($this->behaviorMock);
     }
 
     /**
      * @test
      */
-    public function multipleInitializationFails()
+    public function multipleInitializationFails(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionCode(1535189871);
-        Manager::initialize($this->behaviorProphecy->reveal());
-        Manager::initialize($this->behaviorProphecy->reveal());
+        Manager::initialize($this->behaviorMock);
+        Manager::initialize($this->behaviorMock);
     }
 
     /**
      * @test
      */
-    public function instanceFailsIfNotInitialized()
+    public function instanceFailsIfNotInitialized(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionCode(1535189872);
@@ -58,11 +58,11 @@ class ManagerTest extends TestCase
     /**
      * @test
      */
-    public function instanceFailsIfDestroyed()
+    public function instanceFailsIfDestroyed(): void
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionCode(1535189872);
-        Manager::initialize($this->behaviorProphecy->reveal());
+        Manager::initialize($this->behaviorMock);
         Manager::destroy();
         Manager::instance();
     }
@@ -70,9 +70,9 @@ class ManagerTest extends TestCase
     /**
      * @test
      */
-    public function instanceResolvesIfCalledTwice()
+    public function instanceResolvesIfCalledTwice(): void
     {
-        Manager::initialize($this->behaviorProphecy->reveal());
+        Manager::initialize($this->behaviorMock);
         $firstInstance = Manager::instance();
         $secondInstance = Manager::instance();
         static::assertSame($firstInstance, $secondInstance);
@@ -81,16 +81,16 @@ class ManagerTest extends TestCase
     /**
      * @test
      */
-    public function destroyReturnsTrueIfInitialized()
+    public function destroyReturnsTrueIfInitialized(): void
     {
-        Manager::initialize($this->behaviorProphecy->reveal());
+        Manager::initialize($this->behaviorMock);
         static::assertTrue(Manager::destroy());
     }
 
     /**
      * @test
      */
-    public function destroyReturnsFalseIfNotInitialized()
+    public function destroyReturnsFalseIfNotInitialized(): void
     {
         static::assertFalse(Manager::destroy());
     }
@@ -98,15 +98,17 @@ class ManagerTest extends TestCase
     /**
      * @test
      */
-    public function assertInvocationIsDelegatedToBehavior()
+    public function assertInvocationIsDelegatedToBehavior(): void
     {
         $testPath = uniqid('path');
         $testCommand = uniqid('command');
-        $this->behaviorProphecy->assert($testPath, $testCommand)
-            ->willReturn(false)
-            ->shouldBeCalled();
+        $this->behaviorMock
+            ->expects($this->once())
+            ->method('assert')
+            ->with($testPath, $testCommand)
+            ->willReturn(false);
 
-        Manager::initialize($this->behaviorProphecy->reveal());
+        Manager::initialize($this->behaviorMock);
 
         static::assertFalse(
             Manager::instance()->assert($testPath, $testCommand)


### PR DESCRIPTION
* drops PHP 7.0 compatibility (due to not having nullable types)
* introduces PHP 8.4 compatibility

---

### Breaking Changes

#### ℹ️ Raised min. required PHP version to 7.1

The following classes/interfaces have been modified.
Individual code that is extending/implementing those components needs to be updated manually.

#### ⚠️ \TYPO3\PharStreamWrapper\Collectable

```
- public function collect(PharInvocation $invocation, int $flags = null): bool;
+ public function collect(PharInvocation $invocation, ?int $flags = null): bool;

- public function findByCallback(callable $callback, $reverse = false);
+ public function findByCallback(callable $callback, bool $reverse = false): ?PharInvocation;
```
#### ⚠️ \TYPO3\PharStreamWrapper\Resolvable
```
- public function resolve(string $path, int $flags = null);
+ public function resolve(string $path, ?int $flags = null): ?PharInvocation;
```

---

released in `v4.0.0`
