### PR TITLE
Address PHP8.4 deprecation

### DIFF
--- a/src/Resolver/PharInvocationCollection.php
+++ b/src/Resolver/PharInvocationCollection.php
@@ -39,7 +39,7 @@ class PharInvocationCollection implements Collectable
      * @param null|int $flags
      * @return bool
      */
-    public function collect(PharInvocation $invocation, int $flags = null): bool
+    public function collect(PharInvocation $invocation, ?int $flags = null): bool
     {
         if ($flags === null) {
             $flags = static::UNIQUE_INVOCATION | static::DUPLICATE_ALIAS_WARNING;


### PR DESCRIPTION
TYPO3\PharStreamWrapper\Resolver\PharInvocationCollection::collect(): Implicitly marking parameter $flags as nullable is deprecated, the explicit nullable type must be used instead